### PR TITLE
Support for histogram file download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .gradle
 bin
 build
+.idea/
+histodiff.iml

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-version = '0.1'
+version = '0.2'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Support for histogram file download.
Temporary file is deleted at the end

Usage examples:
```
java -jar histodiff-0.2.jar http://localhost:8000/foo.histo http://localhost:8000/bar.histo
java -jar histodiff-0.2.jar http://localhost:8000/foo.histo ~/tmp/bar.histo 0 150
```