### PR TITLE
Option to allow insecure HTTPS connections and transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ Usage
 -----
 
 ```
-java -jar histodiff.jar file1 file2 [sortBy] [threshold]
+java [-DtrustAllHttpsCerts=true] -jar histodiff.jar file1 file2 [sortBy] [threshold]
 ```
 
  * `file`: path to a file or an URL
  * `sortBy`: 0 (default) to sort results by number of instances, 1 to sort by bytes
  * `threshold`: change in the corresponding dimension has to be above this (0 by default, which means types with no changes in instance counts are omitted)
+ * `-DtrustAllHttpsCerts=true`: this option explicitly allows histodiff to perform "insecure" HTTPS connections and transfers
 
 
 Get, Build, Install


### PR DESCRIPTION
Option to allow insecure HTTPS connections and transfers.

Checked via https server with self-signed certificate
https://anvileight.com/blog/2016/03/20/simple-http-server-with-python/  => SSL Example => Python 2.x

Users have to explicitly set `-DtrustAllHttpsCerts=true` as it can be a bit unsafe to trust everything.